### PR TITLE
added support for IP-based Windows Auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log for SPBypassLoginPage
 
+## Unreleased
+
+* Add property CustomBypassLogin_WindowsAuthIPs to redirect specified client IPs to Windows authentication endpoint
+
 ## SPBypassLoginPage 2019.02.19.10
 
 * Use Azure DevOps to build and release SPBypassLoginPage

--- a/SPBypassLoginPage/LOGIN/Bypass/BypassLogin.aspx.cs
+++ b/SPBypassLoginPage/LOGIN/Bypass/BypassLogin.aspx.cs
@@ -32,16 +32,22 @@ namespace Yvand.SPBypassLoginPage
     public partial class BypassLogin : IdentityModelSignInPageBase
     {
         const string CustomLoginProperty = "CustomBypassLogin";
-        const string WindowsAuthIPsConfig = "WindowsAuthIPs";
+        const string WindowsAuthIPsConfig = "CustomBypassLogin_WindowsAuthIPs";
 
+        private string m_LoginMode;
         public string LoginMode
         {
             get
             {
-                string loginMode = Utilities.AuthModeTrusted;
+                if (!String.IsNullOrWhiteSpace(m_LoginMode))
+                {
+                    return m_LoginMode;
+                }
+
+                m_LoginMode = Utilities.AuthModeTrusted;
                 if (SPFarm.Local.Properties.ContainsKey(CustomLoginProperty))
                 {
-                    loginMode = SPFarm.Local.Properties[CustomLoginProperty].ToString();
+                    m_LoginMode = SPFarm.Local.Properties[CustomLoginProperty].ToString();
                 }
                 if (SPFarm.Local.Properties.ContainsKey(WindowsAuthIPsConfig))
                 {
@@ -49,10 +55,10 @@ namespace Yvand.SPBypassLoginPage
                     string clientIp = this.Request.ServerVariables["REMOTE_ADDR"];
                     if (windowsAuthIPs.IndexOf(clientIp) >= 0)
                     {
-                        loginMode = Utilities.AuthModeWindows;
+                        m_LoginMode = Utilities.AuthModeWindows;
                     }
                 }
-                return loginMode;
+                return m_LoginMode;
             }
         }
 
@@ -91,12 +97,11 @@ namespace Yvand.SPBypassLoginPage
                 SPHttpUtility.NoEncode((string)HttpContext.GetGlobalResourceObject("wss", "login_pagetitle", System.Threading.Thread.CurrentThread.CurrentUICulture));
             ClaimsLogonPageMessage.Text = SPHttpUtility.NoEncode(SPResource.GetString(Strings.SelectAuthenticationMethod));
 
-            var loginMode = LoginMode;
             if (ClientQueryString.Contains(Utilities.DisplayAllAuthNModes) ||
-                String.Equals(loginMode, Utilities.DisplayAllAuthNModes, StringComparison.InvariantCultureIgnoreCase))
+                String.Equals(LoginMode, Utilities.DisplayAllAuthNModes, StringComparison.InvariantCultureIgnoreCase))
                 LetUserChoose();
             else
-                HandleRedirect(loginMode);
+                HandleRedirect(LoginMode);
         }
 
         /// <summary>

--- a/SPBypassLoginPage/SPBypassLoginPage.csproj
+++ b/SPBypassLoginPage/SPBypassLoginPage.csproj
@@ -127,6 +127,6 @@
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\SharePointTools\Microsoft.VisualStudio.SharePoint.targets" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup>
-    <PostBuildEvent>"C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6.1 Tools\x64\gacutil.exe" /f /i "$(TargetPath)"</PostBuildEvent>
+    <PostBuildEvent>"C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\x64\gacutil.exe" /f /i "$(TargetPath)"</PostBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Hey!

We had the requirement that requests from certain IP addresses should be treated as exceptions and should be authenticated with Windows mode.
The use case is as follow: Users manage their profile picture over their SharePoint profile and this image gets replicated into Active Directory. The FIM/MIM which is responsible for this sync process tries to download the profile picture from SharePoint and must be authenticated using Windows mode instead of ADFS / Trusted mode.
Now, we configured the IP address of the MIM server as an exception using the newly introduced farm property "WindowsAuthIPs" (check code for details).

```powershell
$farm = Get-SPFarm
$farm.Properties.Add("WindowsAuthIPs", "10.10.10.10")
$farm.Update()
```
I hope you will find the time to merge my change into your code.
One additional thing: I wasn't able to build your solution because you haven't pushed the Singing-Key-File (SPBypassLoginPage.snk). I then created a completely new solution but would like to replace that solution again with yours as soon as you merged my pull request.
Thanks, 
Lukas 